### PR TITLE
Add react-native-dotenv for environment variable support

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,9 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env
+.env.development
+.env.production
 
 # typescript
 *.tsbuildinfo

--- a/frontend/app/(auth)/login.jsx
+++ b/frontend/app/(auth)/login.jsx
@@ -2,6 +2,7 @@ import { StyleSheet, Text, View, TextInput, TouchableOpacity, ScrollView, Activi
 import React, { useState } from 'react'
 import axios from 'axios'
 import Constants from 'expo-constants'
+import { API_BASE as ENV_API_BASE } from '@env'
 import LoginSvg from '../../assets/auth/login_img.svg'
 
 const PRIMARY = '#6c63ff'
@@ -9,7 +10,7 @@ const BG = '#ffffff'
 const TEXT = '#111111'
 const SUBTLE = '#666666'
 
-const API_BASE = Constants?.expoConfig?.extra?.API_BASE || 'http://localhost:5000'
+const API_BASE = ENV_API_BASE || Constants?.expoConfig?.extra?.API_BASE || 'http://localhost:5000'
 
 const Login = () => {
   const [email, setEmail] = useState('')

--- a/frontend/app/(auth)/register.jsx
+++ b/frontend/app/(auth)/register.jsx
@@ -2,6 +2,7 @@ import { StyleSheet, Text, View, TextInput, TouchableOpacity, ScrollView, Activi
 import React, { useMemo, useState } from 'react'
 import axios from 'axios'
 import Constants from 'expo-constants'
+import { API_BASE as ENV_API_BASE } from '@env'
 import RegisterSvg from '../../assets/auth/register_img.svg'
 
 const PRIMARY = '#6c63ff'
@@ -15,7 +16,7 @@ const ROLE_OPTIONS = [
   { key: 'professional', label: 'Mentor' },
 ]
 
-const API_BASE = Constants?.expoConfig?.extra?.API_BASE || 'http://localhost:5000'
+const API_BASE = ENV_API_BASE || Constants?.expoConfig?.extra?.API_BASE || 'http://localhost:5000'
 
 const Register = () => {
   const [fullName, setFullName] = useState('')

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,20 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'expo-router/babel',
+      [
+        'module:react-native-dotenv',
+        {
+          moduleName: '@env',
+          path: '.env',
+          allowlist: ['API_BASE'],
+          safe: false,
+          verbose: false,
+        },
+      ],
+    ],
+  };
+};
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.4",
+        "react-native-dotenv": "^3.4.11",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "^15.2.0",
@@ -9471,6 +9472,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-dotenv": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-3.4.11.tgz",
+      "integrity": "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
+    "react-native-dotenv": "^3.4.11",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "^15.2.0",


### PR DESCRIPTION
Introduced react-native-dotenv to manage environment variables in the frontend. Updated login and register components to use API_BASE from .env files, and added related entries to .gitignore. Added Babel config to support the new plugin.