### PR TITLE
Integrate expo-splash-screen and update splash logic

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -7,7 +7,6 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "initialRouteName": "splash",
     "extra": {
       "API_BASE": "http://192.168.8.138:5000"
     },

--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -1,15 +1,26 @@
 import { StyleSheet, View, useColorScheme } from 'react-native'
-import React from 'react'
+import React, { useCallback } from 'react'
 import { Stack } from 'expo-router'
 import { themes } from '../constants/colors'
+import * as SplashScreen from 'expo-splash-screen' 
+
+SplashScreen.preventAutoHideAsync().catch(() => {
+  
+})
 
 const RootLayout = () => {
   const colorScheme = useColorScheme()
   const theme = colorScheme === 'dark' ? themes.dark : themes.light
 
+  const onLayoutRootView = useCallback(async () => {
+    try {
+      await SplashScreen.hideAsync()
+    } catch (e) {}
+  }, [])
+
   return (
-    <View style={{ flex: 1, backgroundColor: theme.background }}>
-      <Stack>
+    <View style={{ flex: 1, backgroundColor: theme.background }} onLayout={onLayoutRootView}>
+      <Stack initialRouteName="splash">
         <Stack.Screen 
           name="splash" 
           options={{ 

--- a/frontend/app/splash.jsx
+++ b/frontend/app/splash.jsx
@@ -2,8 +2,9 @@ import React, { useEffect } from 'react'
 import { View, Image, StyleSheet, Animated } from 'react-native'
 import { LinearGradient } from 'expo-linear-gradient'
 import { router } from 'expo-router'
+import * as SplashScreen from 'expo-splash-screen'
 
-const SplashScreen = () => {
+const AppSplash = () => {
   const fadeAnim = new Animated.Value(0)
   const scaleAnim = new Animated.Value(0.8)
 
@@ -24,7 +25,8 @@ const SplashScreen = () => {
     ]).start()
 
     // Navigate to home after 2.5 seconds
-    const timer = setTimeout(() => {
+    const timer = setTimeout( async () => {
+      await SplashScreen.hideAsync()
       router.replace('/')
     }, 2500)
 
@@ -71,4 +73,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default SplashScreen
+export default AppSplash

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -3,7 +3,6 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: [
-      'expo-router/babel',
       [
         'module:react-native-dotenv',
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "expo-linear-gradient": "^15.0.7",
         "expo-linking": "~8.0.8",
         "expo-router": "~6.0.7",
+        "expo-splash-screen": "~31.0.10",
         "expo-status-bar": "~3.0.8",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -6409,6 +6410,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "31.0.10",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.10.tgz",
+      "integrity": "sha512-i6g9IK798mae4yvflstQ1HkgahIJ6exzTCTw4vEdxV0J2SwiW3Tj+CwRjf0te7Zsb+7dDQhBTmGZwdv00VER2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/prebuild-config": "^54.0.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "expo-linear-gradient": "^15.0.7",
     "expo-linking": "~8.0.8",
     "expo-router": "~6.0.7",
+    "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
Added expo-splash-screen to dependencies and implemented manual splash screen control in the app layout and splash screen component. The splash screen now hides after the splash animation and navigation, improving the app's startup experience. Also removed 'expo-router/babel' from Babel config and updated the splash screen component export name.